### PR TITLE
feat: nested price feeds return proper update timestamp

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,102 +1,341 @@
-Business Source License 1.1
-License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. 
-"Business Source License" is a trademark of MariaDB Corporation Ab.
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
------------------------------------------------------------------------------
+Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+<https://fsf.org/>
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
 
-Parameters
+                            Preamble
 
-Licensor:             GearBox Foundation 
+The licenses for most software are designed to take away your
+freedom to share and change it. By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users. This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it. (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.) You can apply it to
+your programs, too.
 
-Licensed Work:        Gearbox Contracts (Gearbox Protocol v3)
-                      The Licensed Work is (c) 2023 GearBox Foundation 
+When we speak of free software, we are referring to freedom, not
+price. Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
 
-Additional Use Grant: Any production use of the Licensed Work is permitted if, 
-                      and as long as, such use is expressly mentioned at 
-                      gearbox.eth (the “List”). Once any specific use is added 
-                      to the List, such production use shall be deemed permitted. 
-                      Once any specific use is removed from the List (including 
-                      if the List is updated to indicate that any specific such 
-                      use is no longer allowed), such use shall no longer be 
-                      permitted, and any license to make such production use 
-                      shall be deemed immediately revoked.
+To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
 
-Change Date:          November 15, 2027
+For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have. You must make sure that they, too, receive or can get the
+source code. And you must show them these terms so they know their
+rights.
 
-Change License:       GNU General Public License v2.0 or later
+We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
 
------------------------------------------------------------------------------
+Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software. If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
 
-Terms
+Finally, any free program is threatened constantly by software
+patents. We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary. To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
 
-The Licensor hereby grants you the right to copy, modify, create derivative works, 
-redistribute, and make non-production use of the Licensed Work. The Licensor may 
-make an Additional Use Grant, above, permitting limited production use.
+The precise terms and conditions for copying, distribution and
+modification follow.
 
-Effective on the Change Date, or the fourth anniversary of the first publicly 
-available distribution of a specific version of the Licensed Work under this License, 
-whichever comes first, the Licensor hereby grants you rights under the terms of the 
-Change License, and the rights granted in the paragraph above terminate.
+                    GNU GENERAL PUBLIC LICENSE
 
-If your use of the Licensed Work does not comply with the requirements currently in 
-effect as described in this License, you must purchase a commercial license from the 
-Licensor, its affiliated entities, or authorized resellers, or you must refrain from 
-using the Licensed Work.
+TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-All copies of the original and modified Licensed Work, and derivative works of the 
-Licensed Work, are subject to this License. This License applies separately for each 
-version of the Licensed Work and the Change Date may vary for each version of the 
-Licensed Work released by Licensor.
+0. This License applies to any program or other work which contains
+   a notice placed by the copyright holder saying it may be distributed
+   under the terms of this General Public License. The "Program", below,
+   refers to any such program or work, and a "work based on the Program"
+   means either the Program or any derivative work under copyright law:
+   that is to say, a work containing the Program or a portion of it,
+   either verbatim or with modifications and/or translated into another
+   language. (Hereinafter, translation is included without limitation in
+   the term "modification".) Each licensee is addressed as "you".
 
-You must conspicuously display this License on each original or modified copy of the 
-Licensed Work. If you receive the Licensed Work in original or modified form from a 
-third party, the terms and conditions set forth in this License apply to your use of 
-that work.
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope. The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
 
-Any use of the Licensed Work in violation of this License will automatically terminate 
-your rights under this License for the current and all other versions of the Licensed 
-Work.
+1. You may copy and distribute verbatim copies of the Program's
+   source code as you receive it, in any medium, provided that you
+   conspicuously and appropriately publish on each copy an appropriate
+   copyright notice and disclaimer of warranty; keep intact all the
+   notices that refer to this License and to the absence of any warranty;
+   and give any other recipients of the Program a copy of this License
+   along with the Program.
 
-This License does not grant you any right in any trademark or logo of Licensor or its 
-affiliates (provided that you may use a trademark or logo of Licensor as expressly 
-required by this License).
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN “AS IS” 
-BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, 
-INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR 
-PURPOSE, NON-INFRINGEMENT, AND TITLE.
-
-MariaDB hereby grants you permission to use this License’s text to license your works, 
-and to refer to it using the trademark “Business Source License”, as long as you comply 
-with the Covenants of Licensor below.
+2. You may modify your copy or copies of the Program or any portion
+   of it, thus forming a work based on the Program, and copy and
+   distribute such modifications or work under the terms of Section 1
+   above, provided that you also meet all of these conditions:
 
 
------------------------------------------------------------------------------
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-Covenants of Licensor
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
 
-In consideration of the right to use this License’s text and the “Business Source License” 
-name and trademark, Licensor covenants to MariaDB, and to all other recipients of the 
-licensed work to be provided by Licensor:
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
 
-   1. To specify as the Change License the GPL Version 2.0 or any later version, or a 
-   license that is compatible with GPL Version 2.0 or a later version, where “compatible” 
-   means that software provided under the Change License can be included in a program with 
-   software provided under GPL Version 2.0 or a later version. Licensor may specify 
-   additional Change Licenses without limitation.
+These requirements apply to the modified work as a whole. If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works. But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
 
-   2. To either: (a) specify an additional grant of rights to use that does not impose 
-   any additional restriction on the right granted in this License, as the Additional 
-   Use Grant; or (b) insert the text “None”.
-   
-   3. To specify a Change Date.
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
 
-   4. Not to modify this License in any other way.
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
 
------------------------------------------------------------------------------
+3. You may copy and distribute the Program (or a work based on it,
+   under Section 2) in object code or executable form under the terms of
+   Sections 1 and 2 above provided that you also do one of the following:
 
-Notice
 
-The Business Source License (this document, or the “License”) is not an Open Source license. 
-However, the Licensed Work will eventually be made available under an Open Source License, 
-as stated in this License.
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it. For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable. However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+4. You may not copy, modify, sublicense, or distribute the Program
+   except as expressly provided under this License. Any attempt
+   otherwise to copy, modify, sublicense or distribute the Program is
+   void, and will automatically terminate your rights under this License.
+   However, parties who have received copies, or rights, from you under
+   this License will not have their licenses terminated so long as such
+   parties remain in full compliance.
+
+5. You are not required to accept this License, since you have not
+   signed it. However, nothing else grants you permission to modify or
+   distribute the Program or its derivative works. These actions are
+   prohibited by law if you do not accept this License. Therefore, by
+   modifying or distributing the Program (or any work based on the
+   Program), you indicate your acceptance of this License to do so, and
+   all its terms and conditions for copying, distributing or modifying
+   the Program or works based on it.
+
+6. Each time you redistribute the Program (or any work based on the
+   Program), the recipient automatically receives a license from the
+   original licensor to copy, distribute or modify the Program subject to
+   these terms and conditions. You may not impose any further
+   restrictions on the recipients' exercise of the rights granted herein.
+   You are not responsible for enforcing compliance by third parties to
+   this License.
+
+7. If, as a consequence of a court judgment or allegation of patent
+   infringement or for any other reason (not limited to patent issues),
+   conditions are imposed on you (whether by court order, agreement or
+   otherwise) that contradict the conditions of this License, they do not
+   excuse you from the conditions of this License. If you cannot
+   distribute so as to satisfy simultaneously your obligations under this
+   License and any other pertinent obligations, then as a consequence you
+   may not distribute the Program at all. For example, if a patent
+   license would not permit royalty-free redistribution of the Program by
+   all those who receive copies directly or indirectly through you, then
+   the only way you could satisfy both it and this License would be to
+   refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices. Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+8. If the distribution and/or use of the Program is restricted in
+   certain countries either by patents or by copyrighted interfaces, the
+   original copyright holder who places the Program under this License
+   may add an explicit geographical distribution limitation excluding
+   those countries, so that distribution is permitted only in or among
+   countries not thus excluded. In such case, this License incorporates
+   the limitation as if written in the body of this License.
+
+9. The Free Software Foundation may publish revised and/or new versions
+   of the General Public License from time to time. Such new versions will
+   be similar in spirit to the present version, but may differ in detail to
+   address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation. If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+10. If you wish to incorporate parts of the Program into other free
+    programs whose distribution conditions are different, write to the author
+    to ask for permission. For software which is copyrighted by the Free
+    Software Foundation, write to the Free Software Foundation; we sometimes
+    make exceptions for this. Our decision will be guided by the two goals
+    of preserving the free status of all derivatives of our free software and
+    of promoting the sharing and reuse of software generally.
+
+                                NO WARRANTY
+
+11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+    FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN
+    OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+    PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+    OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS
+    TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE
+    PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+    REPAIR OR CORRECTION.
+
+12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+    WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+    REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+    INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+    OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+    TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+    YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+    PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+    POSSIBILITY OF SUCH DAMAGES.
+
+                         END OF TERMS AND CONDITIONS
+
+                How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License. Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary. Here is a sample; alter the names:
+
+Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+`Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+<signature of Moe Ghoul>, 1 April 1989
+Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs. If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library. If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository is subject to the Gearbox bug bounty program, per the terms defi
 
 ## Licensing
 
-The primary license for the Gearbox-protocol/integrations-v2 is the Business Source License 1.1 (BUSL-1.1), see [LICENSE](/LICENSE). The files which are NOT licensed under the BUSL-1.1 have appropriate SPDX headers.
+The primary license for the Gearbox-protocol/oracles-v3 is the GNU General Public License v2.0 or later (GPL-2.0-or-later), see [LICENSE](/LICENSE). The files which are NOT licensed under the GPL-2.0-or-later have appropriate SPDX headers.
 
 ## Disclaimer
 

--- a/contracts/interfaces/ILPPriceFeed.sol
+++ b/contracts/interfaces/ILPPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
@@ -35,6 +35,7 @@ interface ILPPriceFeed is IPriceFeed {
     function lowerBound() external view returns (uint256);
     function upperBound() external view returns (uint256);
 
+    function getAggregatePriceAndTimestamp() external view returns (int256 answer, uint256 updatedAt);
     function getAggregatePrice() external view returns (int256 answer);
     function getLPExchangeRate() external view returns (uint256 exchangeRate);
     function getScale() external view returns (uint256 scale);

--- a/contracts/interfaces/LICENSE
+++ b/contracts/interfaces/LICENSE
@@ -1,4 +1,4 @@
-(c) Gearbox Foundation, 2024.
+(c) Gearbox Foundation, 2025.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/contracts/interfaces/balancer/IBalancerStablePool.sol
+++ b/contracts/interfaces/balancer/IBalancerStablePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IBalancerStablePool {

--- a/contracts/interfaces/balancer/IBalancerVault.sol
+++ b/contracts/interfaces/balancer/IBalancerVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IBalancerVault {

--- a/contracts/interfaces/balancer/IBalancerWeightedPool.sol
+++ b/contracts/interfaces/balancer/IBalancerWeightedPool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IBalancerWeightedPool {

--- a/contracts/interfaces/curve/ICurvePool.sol
+++ b/contracts/interfaces/curve/ICurvePool.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface ICurvePool {

--- a/contracts/interfaces/curve/IstETHPoolGateway.sol
+++ b/contracts/interfaces/curve/IstETHPoolGateway.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IstETHPoolGateway {

--- a/contracts/interfaces/lido/IwstETH.sol
+++ b/contracts/interfaces/lido/IwstETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IwstETH {

--- a/contracts/interfaces/mellow/IMellowChainlinkOracle.sol
+++ b/contracts/interfaces/mellow/IMellowChainlinkOracle.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IMellowChainlinkOracle {

--- a/contracts/interfaces/mellow/IMellowVault.sol
+++ b/contracts/interfaces/mellow/IMellowVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IMellowVaultConfigurator} from "./IMellowVaultConfigurator.sol";

--- a/contracts/interfaces/mellow/IMellowVaultConfigurator.sol
+++ b/contracts/interfaces/mellow/IMellowVaultConfigurator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IMellowChainlinkOracle} from "./IMellowChainlinkOracle.sol";

--- a/contracts/interfaces/pendle/IPendleMarket.sol
+++ b/contracts/interfaces/pendle/IPendleMarket.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IPendleMarket {

--- a/contracts/interfaces/pendle/IPendleTokens.sol
+++ b/contracts/interfaces/pendle/IPendleTokens.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.17;
 
 interface IPendleYT {

--- a/contracts/interfaces/pyth/IPyth.sol
+++ b/contracts/interfaces/pyth/IPyth.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {PythStructs} from "./PythStructs.sol";

--- a/contracts/interfaces/pyth/PythStructs.sol
+++ b/contracts/interfaces/pyth/PythStructs.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 contract PythStructs {

--- a/contracts/interfaces/yearn/IYVault.sol
+++ b/contracts/interfaces/yearn/IYVault.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 interface IYVault {

--- a/contracts/oracles/BoundedPriceFeed.sol
+++ b/contracts/oracles/BoundedPriceFeed.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LibString} from "@solady/utils/LibString.sol";
 import {IncorrectParameterException} from "@gearbox-protocol/core-v3/contracts/interfaces/IExceptions.sol";
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
 
 /// @title Bounded price feed
 /// @notice Can be used to provide upper-bounded answers for assets that are
@@ -16,7 +16,7 @@ contract BoundedPriceFeed is IPriceFeed, SanityCheckTrait, PriceFeedValidationTr
     using LibString for string;
     using LibString for bytes32;
 
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::BOUNDED";
 
     uint8 public constant override decimals = 8; // U:[BPF-2]
@@ -60,9 +60,9 @@ contract BoundedPriceFeed is IPriceFeed, SanityCheckTrait, PriceFeedValidationTr
     }
 
     /// @notice Returns the upper-bounded USD price of the token
-    function latestRoundData() external view override returns (uint80, int256 answer, uint256, uint256, uint80) {
-        answer = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck); // U:[BPF-3]
-        return (0, _upperBoundValue(answer), 0, 0, 0); // U:[BPF-3]
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        (int256 answer, uint256 updatedAt) = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck); // U:[BPF-3]
+        return (0, _upperBoundValue(answer), 0, updatedAt, 0); // U:[BPF-3]
     }
 
     /// @dev Upper-bounds given value

--- a/contracts/oracles/BoundedPriceFeed.sol
+++ b/contracts/oracles/BoundedPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/CompositePriceFeed.sol
+++ b/contracts/oracles/CompositePriceFeed.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LibString} from "@solady/utils/LibString.sol";
 import {PriceFeedParams} from "./PriceFeedParams.sol";
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
 
 /// @title Composite price feed
@@ -15,7 +15,7 @@ contract CompositePriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCheck
     using LibString for string;
     using LibString for bytes32;
 
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::COMPOSITE";
 
     uint8 public constant override decimals = 8; // U:[CPF-2]
@@ -68,10 +68,11 @@ contract CompositePriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCheck
     function serialize() external pure override returns (bytes memory) {}
 
     /// @notice Returns the USD price of the target asset, computed as target/base price times base/USD price
-    function latestRoundData() external view override returns (uint80, int256 answer, uint256, uint256, uint80) {
-        answer = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[CPF-3]
-        int256 answer2 = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1); // U:[CPF-3]
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        (int256 answer, uint256 updatedAt) = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[CPF-3]
+        (int256 answer2, uint256 updatedAt2) = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1); // U:[CPF-3]
         answer = (answer * answer2) / targetFeedScale; // U:[CPF-3]
-        return (0, answer, 0, 0, 0);
+        if (updatedAt2 < updatedAt) updatedAt = updatedAt2; // U:[CCF-3]
+        return (0, answer, 0, updatedAt, 0);
     }
 }

--- a/contracts/oracles/CompositePriceFeed.sol
+++ b/contracts/oracles/CompositePriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/ConstantPriceFeed.sol
+++ b/contracts/oracles/ConstantPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/LPPriceFeed.sol
+++ b/contracts/oracles/LPPriceFeed.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import {IUpdatablePriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
 import {PERCENTAGE_FACTOR} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../traits/PriceFeedValidationTrait.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
 
 import {ILPPriceFeed} from "../interfaces/ILPPriceFeed.sol";
@@ -18,9 +17,6 @@ uint256 constant WINDOW_SIZE = 200;
 
 /// @dev Buffer size in bps, used to compute new lower bound given current exchange rate
 uint256 constant BUFFER_SIZE = 100;
-
-/// @dev Minimum interval between two permissionless bounds updates
-uint256 constant UPDATE_BOUNDS_COOLDOWN = 1 days;
 
 /// @title LP price feed
 /// @notice Abstract contract for LP token price feeds.
@@ -70,7 +66,7 @@ abstract contract LPPriceFeed is ILPPriceFeed, Ownable, SanityCheckTrait, PriceF
     }
 
     /// @notice Returns USD price of the LP token with 8 decimals
-    function latestRoundData() external view override returns (uint80, int256 answer, uint256, uint256, uint80) {
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
         uint256 exchangeRate = getLPExchangeRate();
         uint256 lb = lowerBound;
         if (exchangeRate < lb) revert ExchangeRateOutOfBoundsException(); // U:[LPPF-3]
@@ -78,8 +74,15 @@ abstract contract LPPriceFeed is ILPPriceFeed, Ownable, SanityCheckTrait, PriceF
         uint256 ub = _calcUpperBound(lb);
         if (exchangeRate > ub) exchangeRate = ub; // U:[LPPF-3]
 
-        answer = int256((exchangeRate * uint256(getAggregatePrice())) / getScale()); // U:[LPPF-3]
-        return (0, answer, 0, 0, 0);
+        (int256 answer, uint256 updatedAt) = getAggregatePriceAndTimestamp(); // U:[LPPF-3]
+        answer = int256((exchangeRate * uint256(answer)) / getScale()); // U:[LPPF-3]
+        return (0, answer, 0, updatedAt, 0);
+    }
+
+    /// @notice Returns aggregate price of underlying tokens with 8 decimals
+    /// @dev Exists for backward compatability
+    function getAggregatePrice() external view override returns (int256 answer) {
+        (answer,) = getAggregatePriceAndTimestamp();
     }
 
     /// @notice Upper bound for the LP token exchange rate
@@ -89,7 +92,9 @@ abstract contract LPPriceFeed is ILPPriceFeed, Ownable, SanityCheckTrait, PriceF
 
     /// @notice Returns aggregate price of underlying tokens with 8 decimals
     /// @dev Must be implemented by derived price feeds
-    function getAggregatePrice() public view virtual override returns (int256 answer);
+    /// @dev `answer` must be positive
+    /// @dev `updatedAt` must be the earliest of update timestamps of underlying feeds
+    function getAggregatePriceAndTimestamp() public view virtual override returns (int256 answer, uint256 updatedAt);
 
     /// @notice Returns LP token exchange rate
     /// @dev Must be implemented by derived price feeds

--- a/contracts/oracles/LPPriceFeed.sol
+++ b/contracts/oracles/LPPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/PriceFeedParams.sol
+++ b/contracts/oracles/PriceFeedParams.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 struct PriceFeedParams {

--- a/contracts/oracles/SingleAssetLPPriceFeed.sol
+++ b/contracts/oracles/SingleAssetLPPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LPPriceFeed} from "./LPPriceFeed.sol";
@@ -23,7 +23,7 @@ abstract contract SingleAssetLPPriceFeed is LPPriceFeed {
         skipCheck = _validatePriceFeedMetadata(_priceFeed, _stalenessPeriod); // U:[SAPF-1]
     }
 
-    function getAggregatePrice() public view override returns (int256 answer) {
-        answer = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck); // U:[SAPF-2]
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
+        (answer, updatedAt) = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck); // U:[SAPF-2]
     }
 }

--- a/contracts/oracles/SingleAssetLPPriceFeed.sol
+++ b/contracts/oracles/SingleAssetLPPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/ZeroPriceFeed.sol
+++ b/contracts/oracles/ZeroPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/ZeroPriceFeed.sol
+++ b/contracts/oracles/ZeroPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
@@ -8,7 +8,7 @@ import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IP
 /// @title Zero price feed
 /// @notice Always returns zero price as answer
 contract ZeroPriceFeed is IPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::ZERO";
 
     uint8 public constant override decimals = 8; // U:[ZPF-1]
@@ -19,7 +19,7 @@ contract ZeroPriceFeed is IPriceFeed {
     function serialize() external pure override returns (bytes memory) {}
 
     /// @notice Returns zero price
-    function latestRoundData() external pure override returns (uint80, int256, uint256, uint256, uint80) {
-        return (0, 0, 0, 0, 0); // U:[ZPF-2]
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        return (0, 0, 0, block.timestamp, 0); // U:[ZPF-2]
     }
 }

--- a/contracts/oracles/balancer/BPTStablePriceFeed.sol
+++ b/contracts/oracles/balancer/BPTStablePriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LPPriceFeed} from "../LPPriceFeed.sol";
@@ -11,7 +11,7 @@ import {IBalancerStablePool} from "../../interfaces/balancer/IBalancerStablePool
 /// @title Balancer stable pool token price feed
 /// @dev Similarly to Curve stableswap, aggregate function is minimum of underlying tokens prices
 contract BPTStablePriceFeed is LPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::BALANCER_STABLE";
 
     uint8 public immutable numAssets;
@@ -64,23 +64,23 @@ contract BPTStablePriceFeed is LPPriceFeed {
         _setLimiter(_lowerBound); // U:[BAL-S-1]
     }
 
-    function getAggregatePrice() public view override returns (int256 answer) {
-        answer = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[BAL-S-2]
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
+        (answer, updatedAt) = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[BAL-S-2]
 
-        int256 answerA = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
-        if (answerA < answer) answer = answerA; // U:[BAL-S-2]
+        (int256 answerA, uint256 updatedAtA) = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
+        (answer, updatedAt) = _agg(answer, updatedAt, answerA, updatedAtA); // U:[BAL-S-2]
 
         if (numAssets > 2) {
-            answerA = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
-            if (answerA < answer) answer = answerA; // U:[BAL-S-2]
+            (answerA, updatedAtA) = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
+            (answer, updatedAt) = _agg(answer, updatedAt, answerA, updatedAtA); // U:[BAL-S-2]
 
             if (numAssets > 3) {
-                answerA = _getValidatedPrice(priceFeed3, stalenessPeriod3, skipCheck3);
-                if (answerA < answer) answer = answerA; // U:[BAL-S-2]
+                (answerA, updatedAtA) = _getValidatedPrice(priceFeed3, stalenessPeriod3, skipCheck3);
+                (answer, updatedAt) = _agg(answer, updatedAt, answerA, updatedAtA); // U:[BAL-S-2]
 
                 if (numAssets > 4) {
-                    answerA = _getValidatedPrice(priceFeed4, stalenessPeriod4, skipCheck4);
-                    if (answerA < answer) answer = answerA; // U:[BAL-S-2]
+                    (answerA, updatedAtA) = _getValidatedPrice(priceFeed4, stalenessPeriod4, skipCheck4);
+                    (answer, updatedAt) = _agg(answer, updatedAt, answerA, updatedAtA); // U:[BAL-S-2]
                 }
             }
         }
@@ -92,5 +92,13 @@ contract BPTStablePriceFeed is LPPriceFeed {
 
     function getScale() public pure override returns (uint256) {
         return WAD; // U:[BAL-S-1]
+    }
+
+    function _agg(int256 answer1, uint256 updatedAt1, int256 answer2, uint256 updatedAt2)
+        internal
+        view
+        returns (int256 answer, uint256 updatedAt)
+    {
+        return (answer1 < answer2 ? answer1 : answer2, updatedAt1 < updatedAt2 ? updatedAt1 : updatedAt2);
     }
 }

--- a/contracts/oracles/balancer/BPTStablePriceFeed.sol
+++ b/contracts/oracles/balancer/BPTStablePriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/balancer/BPTWeightedPriceFeed.sol
+++ b/contracts/oracles/balancer/BPTWeightedPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/balancer/BPTWeightedPriceFeed.sol
+++ b/contracts/oracles/balancer/BPTWeightedPriceFeed.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -31,7 +31,7 @@ uint256 constant WAD_OVER_USD_FEED_SCALE = 10 ** 10;
 contract BPTWeightedPriceFeed is LPPriceFeed {
     using FixedPoint for uint256;
 
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::BALANCER_WEIGHTED";
 
     /// @notice Balancer vault address
@@ -177,15 +177,18 @@ contract BPTWeightedPriceFeed is LPPriceFeed {
     // PRICING //
     // ------- //
 
-    function getAggregatePrice() public view override returns (int256 answer) {
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
         uint256[] memory weights = _getWeightsArray();
 
         uint256 weightedPrice = FixedPoint.ONE;
         uint256 currentBase = FixedPoint.ONE;
+        updatedAt = type(uint256).max;
+        uint256 updatedAtCurrent;
         for (uint256 i = 0; i < numAssets; ++i) {
             (address priceFeed, uint32 stalenessPeriod, bool skipCheck) = _getPriceFeedParams(i);
-            answer = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
+            (answer, updatedAtCurrent) = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
             answer = answer * int256(WAD_OVER_USD_FEED_SCALE);
+            if (updatedAtCurrent < updatedAt) updatedAt = updatedAtCurrent;
 
             currentBase = currentBase.mulDown(uint256(answer).divDown(weights[i]));
             if (i == numAssets - 1 || weights[i] != weights[i + 1]) {

--- a/contracts/oracles/curve/CurveCryptoLPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveCryptoLPPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/curve/CurveCryptoLPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveCryptoLPPriceFeed.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LPPriceFeed} from "../LPPriceFeed.sol";
@@ -17,7 +17,7 @@ uint256 constant WAD_OVER_USD_FEED_SCALE = 10 ** 10;
 contract CurveCryptoLPPriceFeed is LPPriceFeed {
     using FixedPoint for uint256;
 
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::CURVE_CRYPTO";
 
     uint16 public immutable nCoins;
@@ -62,16 +62,19 @@ contract CurveCryptoLPPriceFeed is LPPriceFeed {
         _setLimiter(_lowerBound); // U:[CRV-C-1]
     }
 
-    function getAggregatePrice() public view override returns (int256 answer) {
-        answer = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0);
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
+        (answer, updatedAt) = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0);
         uint256 product = uint256(answer) * WAD_OVER_USD_FEED_SCALE; // U:[CRV-C-2]
 
-        answer = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
+        uint256 updatedAt2;
+        (answer, updatedAt2) = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
         product = product.mulDown(uint256(answer) * WAD_OVER_USD_FEED_SCALE); // U:[CRV-C-2]
+        if (updatedAt2 < updatedAt) updatedAt = updatedAt2; // U:[CRV-C-2]
 
         if (nCoins == 3) {
-            answer = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
+            (answer, updatedAt2) = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
             product = product.mulDown(uint256(answer) * WAD_OVER_USD_FEED_SCALE); // U:[CRV-C-2]
+            if (updatedAt2 < updatedAt) updatedAt = updatedAt2; // U:[CRV-C-2]
         }
 
         answer = int256(nCoins * product.powDown(WAD / nCoins) / WAD_OVER_USD_FEED_SCALE); // U:[CRV-C-2]

--- a/contracts/oracles/curve/CurveStableLPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveStableLPPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LPPriceFeed} from "../LPPriceFeed.sol";
@@ -12,7 +12,7 @@ import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
 /// @dev For stableswap pools, aggregate is simply the minimum of underlying tokens prices
 /// @dev Older pools may be decoupled from their LP token, so constructor accepts both token and pool
 contract CurveStableLPPriceFeed is LPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::CURVE_STABLE";
 
     uint16 public immutable nCoins;
@@ -64,19 +64,19 @@ contract CurveStableLPPriceFeed is LPPriceFeed {
         _setLimiter(_lowerBound); // U:[CRV-S-1]
     }
 
-    function getAggregatePrice() public view override returns (int256 answer) {
-        answer = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[CRV-S-2]
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
+        (answer, updatedAt) = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0); // U:[CRV-S-2]
 
-        int256 answer2 = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
-        if (answer2 < answer) answer = answer2; // U:[CRV-S-2]
+        (int256 answer2, uint256 updatedAt2) = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
+        (answer, updatedAt) = _agg(answer, updatedAt, answer2, updatedAt2); // U:[CRV-S-2]
 
         if (nCoins > 2) {
-            answer2 = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
-            if (answer2 < answer) answer = answer2; // U:[CRV-S-2]
+            (answer2, updatedAt2) = _getValidatedPrice(priceFeed2, stalenessPeriod2, skipCheck2);
+            (answer, updatedAt) = _agg(answer, updatedAt, answer2, updatedAt2); // U:[CRV-S-2]
 
             if (nCoins > 3) {
-                answer2 = _getValidatedPrice(priceFeed3, stalenessPeriod3, skipCheck3);
-                if (answer2 < answer) answer = answer2; // U:[CRV-S-2]
+                (answer2, updatedAt2) = _getValidatedPrice(priceFeed3, stalenessPeriod3, skipCheck3);
+                (answer, updatedAt) = _agg(answer, updatedAt, answer2, updatedAt2); // U:[CRV-S-2]
             }
         }
     }
@@ -87,5 +87,13 @@ contract CurveStableLPPriceFeed is LPPriceFeed {
 
     function getScale() public pure override returns (uint256) {
         return WAD; // U:[CRV-S-1]
+    }
+
+    function _agg(int256 answer1, uint256 updatedAt1, int256 answer2, uint256 updatedAt2)
+        internal
+        view
+        returns (int256 answer, uint256 updatedAt)
+    {
+        return (answer1 < answer2 ? answer1 : answer2, updatedAt1 < updatedAt2 ? updatedAt1 : updatedAt2);
     }
 }

--- a/contracts/oracles/curve/CurveStableLPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveStableLPPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/curve/CurveTWAPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveTWAPPriceFeed.sol
@@ -7,7 +7,7 @@ import {LibString} from "@solady/utils/LibString.sol";
 import {ICurvePool} from "../../interfaces/curve/ICurvePool.sol";
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
 import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../../traits/PriceFeedValidationTrait.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
 
 /// @title Curve TWAP price feed
@@ -27,7 +27,7 @@ contract CurveTWAPPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCheck
     error UnknownCurveOracleSignatureException();
 
     /// @notice Contract version
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
 
     /// @notice Contract type
     bytes32 public constant override contractType = "PRICE_FEED::CURVE_TWAP";
@@ -126,16 +126,16 @@ contract CurveTWAPPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCheck
     }
 
     /// @notice Returns USD price of the token token with 8 decimals
-    function latestRoundData() external view override returns (uint80, int256 answer, uint256, uint256, uint80) {
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
         uint256 exchangeRate = _getExchangeRate();
 
         if (exchangeRate < lowerBound) revert CurveOracleOutOfBoundsException();
         if (exchangeRate > upperBound) exchangeRate = upperBound;
 
-        int256 underlyingPrice = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
+        (int256 answer, uint256 updatedAt) = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
 
-        answer = int256((exchangeRate * uint256(underlyingPrice)) / WAD);
+        answer = int256((exchangeRate * uint256(answer)) / WAD);
 
-        return (0, answer, 0, 0, 0);
+        return (0, answer, 0, updatedAt, 0);
     }
 }

--- a/contracts/oracles/curve/CurveTWAPPriceFeed.sol
+++ b/contracts/oracles/curve/CurveTWAPPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/curve/CurveUSDPriceFeed.sol
+++ b/contracts/oracles/curve/CurveUSDPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/curve/CurveUSDPriceFeed.sol
+++ b/contracts/oracles/curve/CurveUSDPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {SingleAssetLPPriceFeed} from "../SingleAssetLPPriceFeed.sol";
@@ -12,7 +12,7 @@ import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
 ///         While crvUSD is not an LP token itself, the pricing logic is fairly similar, so existing infrastructure
 ///         is reused. Particularly, the same bounding mechanism is applied to the pool exchange rate.
 contract CurveUSDPriceFeed is SingleAssetLPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::CURVE_USD";
 
     constructor(

--- a/contracts/oracles/erc4626/ERC4626PriceFeed.sol
+++ b/contracts/oracles/erc4626/ERC4626PriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/erc4626/ERC4626PriceFeed.sol
+++ b/contracts/oracles/erc4626/ERC4626PriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -9,7 +9,7 @@ import {SingleAssetLPPriceFeed} from "../SingleAssetLPPriceFeed.sol";
 
 /// @title ERC4626 vault shares price feed
 contract ERC4626PriceFeed is SingleAssetLPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::ERC4626";
 
     /// @dev Amount of shares comprising a single unit (accounting for decimals)

--- a/contracts/oracles/kodiak/KodiakIslandPriceFeed.sol
+++ b/contracts/oracles/kodiak/KodiakIslandPriceFeed.sol
@@ -10,7 +10,7 @@ import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IER
 import {IKodiakIsland} from "../../interfaces/kodiak/IKodiakIsland.sol";
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
 import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../../traits/PriceFeedValidationTrait.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
 
 /// @title Kodiak Island price feed
@@ -24,7 +24,7 @@ contract KodiakIslandPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCh
     uint256 public constant SQRT_WAD = 10 ** 9;
 
     /// @notice Contract version
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
 
     /// @notice Contract type
     bytes32 public constant override contractType = "PRICE_FEED::KODIAK_ISLAND";
@@ -133,9 +133,9 @@ contract KodiakIslandPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCh
     }
 
     /// @notice Returns USD price of the token token with 8 decimals
-    function latestRoundData() external view override returns (uint80, int256 answer, uint256, uint256, uint80) {
-        int256 price0 = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0);
-        int256 price1 = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
+    function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
+        (int256 price0, uint256 updatedAt0) = _getValidatedPrice(priceFeed0, stalenessPeriod0, skipCheck0);
+        (int256 price1, uint256 updatedAt1) = _getValidatedPrice(priceFeed1, stalenessPeriod1, skipCheck1);
 
         uint160 sqrtPriceRatioX96 = _getSqrtPriceRatioX96(price0, price1);
         (uint256 balance0, uint256 balance1) = _getNormalizedBalances(sqrtPriceRatioX96);
@@ -144,8 +144,8 @@ contract KodiakIslandPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCh
 
         uint256 totalSupply = IKodiakIsland(kodiakIsland).totalSupply();
 
-        answer = totalValue / int256(totalSupply);
-
-        return (0, answer, 0, 0, 0);
+        int256 answer = totalValue / int256(totalSupply);
+        uint256 updatedAt = Math.min(updatedAt0, updatedAt1);
+        return (0, answer, 0, updatedAt, 0);
     }
 }

--- a/contracts/oracles/kodiak/KodiakIslandPriceFeed.sol
+++ b/contracts/oracles/kodiak/KodiakIslandPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/lido/WstETHPriceFeed.sol
+++ b/contracts/oracles/lido/WstETHPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
@@ -9,7 +9,7 @@ import {SingleAssetLPPriceFeed} from "../SingleAssetLPPriceFeed.sol";
 
 /// @title wstETH price feed
 contract WstETHPriceFeed is SingleAssetLPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::WSTETH";
 
     constructor(address _owner, uint256 _lowerBound, address _wstETH, address _priceFeed, uint32 _stalenessPeriod)

--- a/contracts/oracles/lido/WstETHPriceFeed.sol
+++ b/contracts/oracles/lido/WstETHPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/mellow/MellowLRTPriceFeed.sol
+++ b/contracts/oracles/mellow/MellowLRTPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
@@ -10,7 +10,7 @@ import {WAD} from "@gearbox-protocol/core-v3/contracts/libraries/Constants.sol";
 
 /// @title Mellow LRT price feed
 contract MellowLRTPriceFeed is SingleAssetLPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::MELLOW_LRT";
 
     /// @dev Amount of base token comprising a single unit (accounting for decimals)

--- a/contracts/oracles/mellow/MellowLRTPriceFeed.sol
+++ b/contracts/oracles/mellow/MellowLRTPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/pendle/PendleTWAPPTPriceFeed.sol
+++ b/contracts/oracles/pendle/PendleTWAPPTPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/pendle/PendleTWAPPTPriceFeed.sol
+++ b/contracts/oracles/pendle/PendleTWAPPTPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
@@ -10,7 +10,7 @@ import {WAD, SECONDS_PER_YEAR} from "@gearbox-protocol/core-v3/contracts/librari
 import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
 import {IPendleMarket} from "../../interfaces/pendle/IPendleMarket.sol";
 import {IPendleYT, IPendleSY} from "../../interfaces/pendle/IPendleTokens.sol";
-import {PriceFeedValidationTrait} from "@gearbox-protocol/core-v3/contracts/traits/PriceFeedValidationTrait.sol";
+import {PriceFeedValidationTrait} from "../../traits/PriceFeedValidationTrait.sol";
 import {SanityCheckTrait} from "@gearbox-protocol/core-v3/contracts/traits/SanityCheckTrait.sol";
 import {PriceFeedParams} from "../PriceFeedParams.sol";
 import {FixedPoint} from "../../libraries/FixedPoint.sol";
@@ -22,7 +22,7 @@ import {LogExpMath} from "../../libraries/LogExpMath.sol";
 ///         2) The PT to asset rate is computed as 1 / (e ^ (ln(IR)_avg * timeToExpiry / secondsPerYear));
 ///         3) The PT price is ptToAssetRate * assetPrice;
 contract PendleTWAPPTPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCheckTrait {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::PENDLE_PT_TWAP";
     uint8 public constant override decimals = 8;
     string public description;
@@ -111,7 +111,7 @@ contract PendleTWAPPTPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCh
 
     /// @notice Returns the USD price of the PT token with 8 decimals
     function latestRoundData() external view override returns (uint80, int256, uint256, uint256, uint80) {
-        int256 answer = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
+        (int256 answer, uint256 updatedAt) = _getValidatedPrice(priceFeed, stalenessPeriod, skipCheck);
 
         if (expiry > block.timestamp) {
             answer = int256(FixedPoint.mulDown(uint256(answer), _getPTToAssetRate()));
@@ -127,6 +127,6 @@ contract PendleTWAPPTPriceFeed is IPriceFeed, PriceFeedValidationTrait, SanityCh
             answer = int256(FixedPoint.divDown(uint256(answer), syIndex));
         }
 
-        return (0, answer, 0, 0, 0);
+        return (0, answer, 0, updatedAt, 0);
     }
 }

--- a/contracts/oracles/updatable/PythPriceFeed.sol
+++ b/contracts/oracles/updatable/PythPriceFeed.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LibString} from "@solady/utils/LibString.sol";

--- a/contracts/oracles/updatable/RedstonePriceFeed.sol
+++ b/contracts/oracles/updatable/RedstonePriceFeed.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {LibString} from "@solady/utils/LibString.sol";

--- a/contracts/oracles/yearn/YearnPriceFeed.sol
+++ b/contracts/oracles/yearn/YearnPriceFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/oracles/yearn/YearnPriceFeed.sol
+++ b/contracts/oracles/yearn/YearnPriceFeed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 // Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
+// (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;
 
 import {IYVault} from "../../interfaces/yearn/IYVault.sol";
@@ -8,7 +8,7 @@ import {SingleAssetLPPriceFeed} from "../SingleAssetLPPriceFeed.sol";
 
 /// @title Yearn price feed
 contract YearnPriceFeed is SingleAssetLPPriceFeed {
-    uint256 public constant override version = 3_10;
+    uint256 public constant override version = 3_11;
     bytes32 public constant override contractType = "PRICE_FEED::YEARN";
 
     /// @dev Scale of yVault's pricePerShare

--- a/contracts/test/live/PricePrinter.t.sol
+++ b/contracts/test/live/PricePrinter.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test/live/kodiak/KodiakIslandLive.t.sol
+++ b/contracts/test/live/kodiak/KodiakIslandLive.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test/mocks/balancer/BalancerStablePoolMock.sol
+++ b/contracts/test/mocks/balancer/BalancerStablePoolMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IBalancerStablePool} from "../../../interfaces/balancer/IBalancerStablePool.sol";

--- a/contracts/test/mocks/balancer/BalancerVaultMock.sol
+++ b/contracts/test/mocks/balancer/BalancerVaultMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IBalancerVault} from "../../../interfaces/balancer/IBalancerVault.sol";

--- a/contracts/test/mocks/balancer/BalancerWeightedPoolMock.sol
+++ b/contracts/test/mocks/balancer/BalancerWeightedPoolMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IBalancerWeightedPool} from "../../../interfaces/balancer/IBalancerWeightedPool.sol";

--- a/contracts/test/mocks/curve/CurvePoolMock.sol
+++ b/contracts/test/mocks/curve/CurvePoolMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {ICurvePool} from "../../../interfaces/curve/ICurvePool.sol";

--- a/contracts/test/mocks/erc4626/ERC4626Mock.sol
+++ b/contracts/test/mocks/erc4626/ERC4626Mock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/test/mocks/lido/WstETHMock.sol
+++ b/contracts/test/mocks/lido/WstETHMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IwstETH} from "../../../interfaces/lido/IwstETH.sol";

--- a/contracts/test/mocks/mellow/MellowChainlinkOracleMock.sol
+++ b/contracts/test/mocks/mellow/MellowChainlinkOracleMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IMellowChainlinkOracle} from "../../../interfaces/mellow/IMellowChainlinkOracle.sol";

--- a/contracts/test/mocks/mellow/MellowVaultConfiguratorMock.sol
+++ b/contracts/test/mocks/mellow/MellowVaultConfiguratorMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IMellowChainlinkOracle} from "../../../interfaces/mellow/IMellowChainlinkOracle.sol";

--- a/contracts/test/mocks/mellow/MellowVaultMock.sol
+++ b/contracts/test/mocks/mellow/MellowVaultMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IMellowVault} from "../../../interfaces/mellow/IMellowVault.sol";

--- a/contracts/test/mocks/pyth/PythMock.sol
+++ b/contracts/test/mocks/pyth/PythMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PythStructs} from "../../../interfaces/pyth/PythStructs.sol";

--- a/contracts/test/mocks/yearn/YVaultMock.sol
+++ b/contracts/test/mocks/yearn/YVaultMock.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IYVault} from "../../../interfaces/yearn/IYVault.sol";

--- a/contracts/test/suites/PriceFeedDeployer.sol
+++ b/contracts/test/suites/PriceFeedDeployer.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.10;
 
 import {Test} from "forge-std/Test.sol";

--- a/contracts/test/unit/BoundedPriceFeed.unit.t.sol
+++ b/contracts/test/unit/BoundedPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -25,6 +23,7 @@ contract BoundedPriceFeedUnitTest is Test {
 
     function setUp() public {
         underlyingPriceFeed = new PriceFeedMock(1e8, 8);
+        underlyingPriceFeed.setParams(0, 0, block.timestamp - 0.5 days, 0);
 
         priceFeed = new BoundedPriceFeed(address(underlyingPriceFeed), 1 days, 1.1e8, "TEST / USD");
     }
@@ -56,13 +55,15 @@ contract BoundedPriceFeedUnitTest is Test {
 
     /// @notice U:[BPF-3]: `latestRoundData` works as expected
     function test_U_BPF_03_latestRoundData_works_as_expected() public {
-        (, int256 answer,,,) = priceFeed.latestRoundData();
+        (, int256 answer,, uint256 updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 1e8, "Incorrect answer");
+        assertEq(updatedAt, block.timestamp - 0.5 days, "Incorrect update timestamp");
 
         // upper-bounds answer
         underlyingPriceFeed.setPrice(1.2e8);
-        (, answer,,,) = priceFeed.latestRoundData();
+        (, answer,, updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 1.1e8, "Incorrect upper bounded answer");
+        assertEq(updatedAt, block.timestamp - 0.5 days, "Incorrect update timestamp");
 
         // reverts on stale answer
         underlyingPriceFeed.setParams(0, 0, block.timestamp - 2 days, 0);

--- a/contracts/test/unit/CompositePriceFeed.unit.t.sol
+++ b/contracts/test/unit/CompositePriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -73,11 +71,21 @@ contract CompositePriceFeedUnitTest is Test {
 
     /// @notice U:[CPF-3]: `latestRoundData` works as expected
     function test_U_CPF_03_latestRoundData_works_as_expected() public {
-        (, int256 answer,,,) = priceFeed.latestRoundData();
+        targetPriceFeed.setParams(0, 0, block.timestamp - 0.3 days, 0);
+        basePriceFeed.setParams(0, 0, block.timestamp - 0.6 days, 0);
+        (, int256 answer,, uint256 updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 1e8, "Incorrect answer");
+        assertEq(updatedAt, block.timestamp - 0.6 days, "Incorrect updatedAt");
+
+        targetPriceFeed.setParams(0, 0, block.timestamp - 0.4 days, 0);
+        basePriceFeed.setParams(0, 0, block.timestamp - 0.2 days, 0);
+        (, answer,, updatedAt,) = priceFeed.latestRoundData();
+        assertEq(answer, 1e8, "Incorrect answer");
+        assertEq(updatedAt, block.timestamp - 0.4 days, "Incorrect updatedAt");
 
         // reverts on stale target price feed answer
         targetPriceFeed.setParams(0, 0, block.timestamp - 2 days, 0);
+        basePriceFeed.setParams(0, 0, block.timestamp, 0);
         vm.expectRevert(StalePriceException.selector);
         priceFeed.latestRoundData();
 

--- a/contracts/test/unit/ConstantPriceFeed.unit.t.sol
+++ b/contracts/test/unit/ConstantPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";

--- a/contracts/test/unit/LPPriceFeed.harness.sol
+++ b/contracts/test/unit/LPPriceFeed.harness.sol
@@ -19,8 +19,8 @@ contract LPPriceFeedHarness is LPPriceFeed {
         _answer = answer;
     }
 
-    function getAggregatePrice() public view override returns (int256 answer) {
-        return _answer;
+    function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
+        return (_answer, block.timestamp);
     }
 
     function hackLPExchangeRate(uint256 exchangeRate) external {

--- a/contracts/test/unit/LPPriceFeed.harness.sol
+++ b/contracts/test/unit/LPPriceFeed.harness.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {LPPriceFeed} from "../../oracles/LPPriceFeed.sol";
@@ -10,17 +8,19 @@ contract LPPriceFeedHarness is LPPriceFeed {
     uint256 public constant override version = 0;
 
     int256 _answer;
+    uint256 _updatedAt;
     uint256 _exchangeRate;
     uint256 _scale;
 
     constructor(address _owner, address _lpToken, address _lpContract) LPPriceFeed(_owner, _lpToken, _lpContract) {}
 
-    function hackAggregatePrice(int256 answer) external {
+    function hackAggregatePriceAndTimestamp(int256 answer, uint256 updatedAt) external {
         _answer = answer;
+        _updatedAt = updatedAt;
     }
 
     function getAggregatePriceAndTimestamp() public view override returns (int256 answer, uint256 updatedAt) {
-        return (_answer, block.timestamp);
+        return (_answer, _updatedAt);
     }
 
     function hackLPExchangeRate(uint256 exchangeRate) external {

--- a/contracts/test/unit/LPPriceFeed.unit.t.sol
+++ b/contracts/test/unit/LPPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -55,7 +53,7 @@ contract LPPriceFeedUnitTest is Test {
     /// @notice U:[LPPF-3]: `latestRoundData` works as expected
     function test_U_LPPF_03_latestRoundData_works_as_expected() public {
         priceFeed.hackLowerBound(1 ether);
-        priceFeed.hackAggregatePrice(2e8);
+        priceFeed.hackAggregatePriceAndTimestamp(2e8, block.timestamp - 10);
         priceFeed.hackScale(1 ether);
 
         // reverts if exchange rate below lower bound
@@ -65,13 +63,15 @@ contract LPPriceFeedUnitTest is Test {
 
         // computes normally if exchange rate within bounds
         priceFeed.hackLPExchangeRate(1.01 ether);
-        (, int256 answer,,,) = priceFeed.latestRoundData();
+        (, int256 answer,, uint256 updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 2.02e8, "Incorrect answer (exchange rate within bounds)");
+        assertEq(updatedAt, block.timestamp - 10, "Incorrect update timestamp (exchange rate within bounds)");
 
         // limits if exchange rate above upper bound
         priceFeed.hackLPExchangeRate(2 ether);
-        (, answer,,,) = priceFeed.latestRoundData();
+        (, answer,, updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 2.04e8, "Incorrect answer (exchange rate above upper bound)");
+        assertEq(updatedAt, block.timestamp - 10, "Incorrect update timestamp (exchange rate above upper bound)");
     }
 
     /// @notice U:[LPPF-4]: `upperBound` works as expected

--- a/contracts/test/unit/PriceFeedUnitTestHelper.sol
+++ b/contracts/test/unit/PriceFeedUnitTestHelper.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -16,6 +14,7 @@ contract PriceFeedUnitTestHelper is Test {
 
     function _setUp() internal {
         underlyingPriceFeed = new PriceFeedMock(2e8, 8);
+        underlyingPriceFeed.setParams(0, 0, block.timestamp - 0.5 days, 0);
         vm.mockCall(
             address(underlyingPriceFeed), abi.encodeCall(PriceFeedMock.description, ()), abi.encode("TEST / USD")
         );

--- a/contracts/test/unit/SingleAssetLPPriceFeed.harness.sol
+++ b/contracts/test/unit/SingleAssetLPPriceFeed.harness.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {SingleAssetLPPriceFeed} from "../../oracles/SingleAssetLPPriceFeed.sol";

--- a/contracts/test/unit/SingleAssetLPPriceFeed.unit.t.sol
+++ b/contracts/test/unit/SingleAssetLPPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -62,8 +60,10 @@ contract SingleAssetLPPriceFeedUnitTest is Test {
     /// @notice U:[SAPF-2]: `getAggregatePrice` works as expected
     function test_U_SAPF_02_getAggregatePrice_works_as_expected() public {
         // returns same answer as underlying price feed
-        int256 answer = priceFeed.getAggregatePrice();
+        underlyingPriceFeed.setParams(0, 0, block.timestamp - 0.5 days, 0);
+        (int256 answer, uint256 updatedAt) = priceFeed.getAggregatePriceAndTimestamp();
         assertEq(answer, 1e8, "Incorrect answer");
+        assertEq(updatedAt, block.timestamp - 0.5 days, "Incorrect update timestamp");
 
         // reverts on stale answer
         underlyingPriceFeed.setParams(0, 0, block.timestamp - 2 days, 0);

--- a/contracts/test/unit/ZeroPriceFeed.unit.t.sol
+++ b/contracts/test/unit/ZeroPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {Test} from "forge-std/Test.sol";
@@ -25,7 +23,8 @@ contract ZeroPriceFeedUnitTest is Test {
 
     /// @notice U:[ZPF-2]: `latestRoundData` works as expected
     function test_U_ZPF_02_latestRoundData_works_as_expected() public view {
-        (, int256 answer,,,) = priceFeed.latestRoundData();
+        (, int256 answer,, uint256 updatedAt,) = priceFeed.latestRoundData();
         assertEq(answer, 0, "Incorrect answer");
+        assertEq(updatedAt, block.timestamp, "Incorrect update timestamp");
     }
 }

--- a/contracts/test/unit/balancer/BPTStablePriceFeed.unit.t.sol
+++ b/contracts/test/unit/balancer/BPTStablePriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";

--- a/contracts/test/unit/balancer/BPTWeightedPriceFeed.harness.sol
+++ b/contracts/test/unit/balancer/BPTWeightedPriceFeed.harness.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedParams} from "../../../oracles/PriceFeedParams.sol";

--- a/contracts/test/unit/balancer/BPTWeightedPriceFeed.unit.t.sol
+++ b/contracts/test/unit/balancer/BPTWeightedPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";

--- a/contracts/test/unit/curve/CurveCryptoLPPriceFeed.unit.t.sol
+++ b/contracts/test/unit/curve/CurveCryptoLPPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";
@@ -31,6 +29,7 @@ contract CurveCryptoLPPriceFeedUnitTest is PriceFeedUnitTestHelper {
 
         for (uint256 i; i < 3; ++i) {
             underlyingPriceFeeds[i] = new PriceFeedMock(int256(1e8 * 4 ** i), 8);
+            underlyingPriceFeeds[i].setParams(0, 0, block.timestamp - (i + 1) * 1 days / 4, 0);
         }
     }
 
@@ -66,8 +65,9 @@ contract CurveCryptoLPPriceFeedUnitTest is PriceFeedUnitTestHelper {
             priceFeed = _newCurvePriceFeed(numFeeds, 1.02 ether);
             assertEq(priceFeed.nCoins(), numFeeds, "Incorrect nCoins");
 
-            int256 answer = priceFeed.getAggregatePrice();
+            (int256 answer, uint256 updatedAt) = priceFeed.getAggregatePriceAndTimestamp();
             assertApproxEqAbs(answer, int256(int256(numFeeds * 1e8 * 2 ** (numFeeds - 1))), 1, "Incorrect answer");
+            assertEq(updatedAt, block.timestamp - numFeeds * 1 days / 4, "Incorrect update timestamp");
         }
     }
 

--- a/contracts/test/unit/curve/CurveStableLPPriceFeed.unit.t.sol
+++ b/contracts/test/unit/curve/CurveStableLPPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";
@@ -31,6 +29,7 @@ contract CurveStableLPPriceFeedUnitTest is PriceFeedUnitTestHelper {
 
         for (uint256 i; i < 4; ++i) {
             underlyingPriceFeeds[i] = new PriceFeedMock(int256(1e6 * (100 - i)), 8);
+            underlyingPriceFeeds[i].setParams(0, 0, block.timestamp - (i + 1) * 1 days / 5, 0);
         }
     }
 
@@ -66,8 +65,9 @@ contract CurveStableLPPriceFeedUnitTest is PriceFeedUnitTestHelper {
             priceFeed = _newCurvePriceFeed(numFeeds, 1.02 ether);
             assertEq(priceFeed.nCoins(), numFeeds, "Incorrect nCoins");
 
-            int256 answer = priceFeed.getAggregatePrice();
+            (int256 answer, uint256 updatedAt) = priceFeed.getAggregatePriceAndTimestamp();
             assertEq(answer, int256(1e6 * (101 - numFeeds)), "Incorrect answer");
+            assertEq(updatedAt, block.timestamp - numFeeds * 1 days / 5, "Incorrect update timestamp");
         }
     }
 

--- a/contracts/test/unit/curve/CurveTWAPPriceFeed.unit.t.sol
+++ b/contracts/test/unit/curve/CurveTWAPPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";
@@ -55,8 +53,9 @@ contract CurveTWAPPriceFeedUnitTest is PriceFeedUnitTestHelper {
 
         // latestRoundData
         vm.expectCall(address(curvePool), abi.encodeWithSignature("price_oracle()"));
-        (, int256 price,,,) = priceFeed.latestRoundData();
+        (, int256 price,, uint256 updatedAt,) = priceFeed.latestRoundData();
         assertEq(price, int256((1.03 ether * 2e8) / WAD), "Incorrect price");
+        assertEq(updatedAt, block.timestamp - 0.5 days, "Incorrect update timestamp");
 
         curvePool.hack_withIndex(true);
         vm.expectCall(address(curvePool), abi.encodeWithSignature("price_oracle(uint256)", 0));

--- a/contracts/test/unit/curve/CurveUSDPriceFeed.unit.t.sol
+++ b/contracts/test/unit/curve/CurveUSDPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";

--- a/contracts/test/unit/erc4626/ERC4626PriceFeed.unit.t.sol
+++ b/contracts/test/unit/erc4626/ERC4626PriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";

--- a/contracts/test/unit/lido/WstETHPriceFeed.unit.t.sol
+++ b/contracts/test/unit/lido/WstETHPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";

--- a/contracts/test/unit/mellow/MellowLRTPriceFeed.unit.t.sol
+++ b/contracts/test/unit/mellow/MellowLRTPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {IMellowVault} from "../../../interfaces/mellow/IMellowVault.sol";

--- a/contracts/test/unit/updatable/PythPriceFeed.unit.t.sol
+++ b/contracts/test/unit/updatable/PythPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.10;
 
 import {

--- a/contracts/test/unit/updatable/RedstonePriceFeed.unit.t.sol
+++ b/contracts/test/unit/updatable/RedstonePriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.10;
 
 import {

--- a/contracts/test/unit/yearn/YearnPriceFeed.unit.t.sol
+++ b/contracts/test/unit/yearn/YearnPriceFeed.unit.t.sol
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: UNLICENSED
-// Gearbox Protocol. Generalized leverage for DeFi protocols
-// (c) Gearbox Foundation, 2024.
 pragma solidity ^0.8.23;
 
 import {PriceFeedUnitTestHelper} from "../PriceFeedUnitTestHelper.sol";

--- a/contracts/traits/PriceFeedValidationTrait.sol
+++ b/contracts/traits/PriceFeedValidationTrait.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-2.0-or-later
 // Gearbox Protocol. Generalized leverage for DeFi protocols
 // (c) Gearbox Foundation, 2025.
 pragma solidity ^0.8.23;

--- a/contracts/traits/PriceFeedValidationTrait.sol
+++ b/contracts/traits/PriceFeedValidationTrait.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Gearbox Protocol. Generalized leverage for DeFi protocols
+// (c) Gearbox Foundation, 2025.
+pragma solidity ^0.8.23;
+
+import {
+    AddressIsNotContractException,
+    IncorrectParameterException,
+    IncorrectPriceException,
+    IncorrectPriceFeedException,
+    StalePriceException
+} from "@gearbox-protocol/core-v3/contracts/interfaces/IExceptions.sol";
+import {IPriceFeed} from "@gearbox-protocol/core-v3/contracts/interfaces/base/IPriceFeed.sol";
+import {OptionalCall} from "@gearbox-protocol/core-v3/contracts/libraries/OptionalCall.sol";
+
+/// @title Price feed validation trait
+abstract contract PriceFeedValidationTrait {
+    /// @dev Ensures that price feed's answer is positive and not stale.
+    ///      If `skipCheck` is true, only checks that price is non-negative to allow zero price feed to be used.
+    function _checkAnswer(int256 price, uint256 updatedAt, uint32 stalenessPeriod, bool skipCheck) internal view {
+        if (price < 0 || !skipCheck && price == 0) revert IncorrectPriceException();
+        if (!skipCheck && block.timestamp >= updatedAt + stalenessPeriod) revert StalePriceException();
+    }
+
+    /// @dev Validates that `priceFeed` is a contract that adheres to Chainlink interface
+    /// @dev Reverts if `priceFeed` does not have exactly 8 decimals
+    /// @dev Reverts if `stalenessPeriod` is inconsistent with `priceFeed`'s `skipPriceCheck()` flag
+    ///      (which is considered to be false if `priceFeed` does not have this function)
+    function _validatePriceFeedMetadata(address priceFeed, uint32 stalenessPeriod)
+        internal
+        view
+        returns (bool skipCheck)
+    {
+        if (priceFeed.code.length == 0) revert AddressIsNotContractException(priceFeed);
+
+        try IPriceFeed(priceFeed).decimals() returns (uint8 _decimals) {
+            if (_decimals != 8) revert IncorrectPriceFeedException();
+        } catch {
+            revert IncorrectPriceFeedException();
+        }
+
+        // NOTE: Some external price feeds without `skipPriceCheck` may have a fallback function that changes state,
+        // which can cause a `THROW` that burns all gas, or does not change state and instead returns empty data.
+        // To handle these cases, we use a special call construction with a strict gas limit.
+        (bool success, bytes memory returnData) = OptionalCall.staticCallOptionalSafe({
+            target: priceFeed,
+            data: abi.encodeWithSelector(IPriceFeed.skipPriceCheck.selector),
+            gasAllowance: 10_000
+        });
+        if (success) skipCheck = abi.decode(returnData, (bool));
+        if (skipCheck && stalenessPeriod != 0 || !skipCheck && stalenessPeriod == 0) {
+            revert IncorrectParameterException();
+        }
+    }
+
+    /// @dev Returns answer from a price feed with optional sanity and staleness checks
+    function _getValidatedPrice(address priceFeed, uint32 stalenessPeriod, bool skipCheck)
+        internal
+        view
+        returns (int256 answer, uint256 updatedAt)
+    {
+        (, answer,, updatedAt,) = IPriceFeed(priceFeed).latestRoundData();
+        _checkAnswer(answer, updatedAt, stalenessPeriod, skipCheck);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "contracts",
     "scripts"
   ],
-  "license": "BUSL-1.1",
+  "license": "GPL-2.0-or-later",
   "scripts": {
     "prepare": "husky install",
     "prettier": "forge fmt",


### PR DESCRIPTION
Also changes licensing of price feeds to `GPL-2.0-or-later`, while tests are now _properly_ unlicensed (so no copyright strings there).